### PR TITLE
Fixed user auth create

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -46,7 +46,7 @@ module.exports = function(){
         }
 
         // population didn't work try again
-        if(typeof auth.user === 'number'){
+        if(typeof auth.user !== 'object'){
           if(!self.hasOwnProperty('_findOrCreateAuthAttempts')){
             self._findOrCreateAuthAttempts = 0;
           }
@@ -86,12 +86,7 @@ module.exports = function(){
           // just fire off update to user object so we can get the 
           // backwards association going.
           if(!auth.user.auth){
-              if(!auth.user.id || auth.user.id === 'undefined'){
-                  waterlock.User.update(criteria, {auth:auth.id}).exec(function(){});
-              }
-              else {
-                  waterlock.User.update(auth.user.id, {auth:auth.id}).exec(function(){});
-              }
+          	waterlock.User.update(auth.user.id, {auth:auth.id}).exec(function(){});
           }
           
           cb(err, self._invertAuth(auth));


### PR DESCRIPTION
the waterlock.User.update(auth.user.id, {auth:auth.id}).exec(function(){}); method was causing all user records to update the auth field to the newly created auth id when auth.user.id was missing or undefined.
