### PR TITLE
fixed jwt model - data too long for column token in mysql

### DIFF
--- a/lib/models/jwt.js
+++ b/lib/models/jwt.js
@@ -9,7 +9,10 @@ exports.attributes = function(attributes){
   var _ = require('lodash');
 
   var template = {
-    token: 'string',
+    token: {
+      type: 'text',
+      maxLength: 512
+    },
     uses: {
       collection: 'use',
       via: 'jsonWebToken'
@@ -19,7 +22,7 @@ exports.attributes = function(attributes){
     },
     revoked: {
       type: 'boolean',
-      defaultsTo: false 
+      defaultsTo: false
     }
   };
 


### PR DESCRIPTION
I'm using mysql with waterlock and I got this error:

_Details:  Error: ER_DATA_TOO_LONG: Data too long for column 'token' at row 1_

To fix it I changed the token type to "text" since token length was always greater than 255 characters and
in MySQL VARCHAR columns are variable-length strings and the length can be specified as a value from 0 to 255 before MySQL 5.0.3, and 0 to 65,535 in 5.0.3 and later versions.
