### PR TITLE
Added check for j===undefined in case token is missing

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -135,7 +135,7 @@ module.exports = function(){
           return cb(err);
         }
         
-        if(!j){
+        if(!j || j === undefined){
           waterlock.logger.debug('access token not found');
           return cb('Token not found');
         }


### PR DESCRIPTION
An exception was thrown if token is not specified in the headers or elsewhere (j===undefined). I added check for that and now REST API returns proper error status code and message.