### PR TITLE
Fixes "jwt" responses not returning a statusCode.

### DIFF
--- a/lib/cycle.js
+++ b/lib/cycle.js
@@ -67,7 +67,7 @@ module.exports = function() {
             result['user'] = user;
           }
 
-          res.json(result);
+          res.ok(result);
         });
       }else if (typeof postResponse === 'string' && this._isURI(postResponse)) {
         res.redirect(postResponse);
@@ -177,7 +177,7 @@ module.exports = function() {
             result['user'] = user;
           }
 
-          res.json(result);
+          res.ok(result);
         });
       } else if(typeof postResponse === 'string' && this._isURI(postResponse)){
         res.redirect(postResponse);


### PR DESCRIPTION
This fixes an issue I had where Swagger would not think the waterlock response was a "200" success because no status code is returned. I should note ok.js seems to already run res.jsonx() so sending the json object to res.ok() is probably okay if not the best.