### PR TITLE
Stateless mode

### DIFF
--- a/lib/cycle.js
+++ b/lib/cycle.js
@@ -9,6 +9,7 @@ var _ = require('lodash');
  */
 module.exports = function() {
   var waterlock = this;
+  var stateless = waterlock.config.jsonWebTokens.stateless;
 
   return {
 
@@ -43,7 +44,7 @@ module.exports = function() {
       });
 
       // store user in && authenticate the session if not stateless
-      if ( !waterlock.config.jsonWebTokens.stateless ) {
+      if ( !stateless ) {
         req.session.user = user;
         req.session.authenticated = true;
       }
@@ -107,11 +108,13 @@ module.exports = function() {
         });
       }
 
-      if (req.session.authenticated) {
-        req.session.authenticated = false;
-      }
+      if ( !stateless ) {
+        if (req.session.authenticated) {
+          req.session.authenticated = false;
+        }
 
-      delete(req.session.user);
+        delete(req.session.user);
+      }
 
       // now respond or redirect
       var postResponse = this._resolvePostAction(waterlock.config.postActions.register.failure,
@@ -156,7 +159,7 @@ module.exports = function() {
       });
 
       // store user in && authenticate the session if not stateless
-      if ( !waterlock.config.jsonWebTokens.stateless ) {
+      if ( !stateless ) {
         req.session.user = user;
         req.session.authenticated = true;
       }
@@ -219,12 +222,13 @@ module.exports = function() {
         });
       }
 
-      if (req.session.authenticated) {
-        req.session.authenticated = false;
+      if ( !stateless ) {
+        if (req.session.authenticated) {
+          req.session.authenticated = false;
+        }
+
+        delete(req.session.user);
       }
-
-      delete(req.session.user);
-
       // now respond or redirect
       var postResponse = this._resolvePostAction(waterlock.config.postActions.login.failure,
         error);
@@ -245,12 +249,18 @@ module.exports = function() {
      */
     logout: function(req, res) {
       waterlock.logger.debug('user logout');
-      delete(req.session.user);
 
-      if (req.session.authenticated) {
+      if ( !stateless ) {
+        delete(req.session.user);
+
+        if (req.session.authenticated) {
+          this.logoutSuccess(req, res);
+        } else {
+          this.logoutFailure(req, res);
+        }
+      }
+      else {
         this.logoutSuccess(req, res);
-      } else {
-        this.logoutFailure(req, res);
       }
     },
 
@@ -263,7 +273,9 @@ module.exports = function() {
      */
     logoutSuccess: function(req, res) {
 
-      req.session.authenticated = false;
+      if ( !stateless ) {
+        req.session.authenticated = false;
+      }
 
       var defaultString = 'You have successfully logged out.';
 

--- a/lib/cycle.js
+++ b/lib/cycle.js
@@ -42,9 +42,11 @@ module.exports = function() {
         }
       });
 
-      // store user in && authenticate the session
-      req.session.user = user;
-      req.session.authenticated = true;
+      // store user in && authenticate the session if not stateless
+      if ( !waterlock.config.jsonWebTokens.stateless ) {
+        req.session.user = user;
+        req.session.authenticated = true;
+      }
 
       // now respond or redirect
       var postResponse = this._resolvePostAction(waterlock.config.postActions.register.success, user);
@@ -153,9 +155,11 @@ module.exports = function() {
         }
       });
 
-      // store user in && authenticate the session
-      req.session.user = user;
-      req.session.authenticated = true;
+      // store user in && authenticate the session if not stateless
+      if ( !waterlock.config.jsonWebTokens.stateless ) {
+        req.session.user = user;
+        req.session.authenticated = true;
+      }
       // now respond or redirect
       var postResponse = this._resolvePostAction(waterlock.config.postActions.login.success,
         user);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "commander": "~2.8.1",
-    "jwt-simple": "~0.3.0",
+    "jwt-simple": "~0.5.0",
     "lodash": "~3.8.0",
     "moment": "~2.10.3",
     "node-uuid": "~1.4.3",


### PR DESCRIPTION
If `waterlock.config.jsonWebTokens.stateless`is set to true we should avoid setting user session. 
Useful in rest-only applications where sessions are turned off.
