### PR TITLE
make login success response based on authentication method / type

### DIFF
--- a/lib/cycle.js
+++ b/lib/cycle.js
@@ -49,10 +49,11 @@ module.exports = function() {
       // now respond or redirect
       var postResponse = user;
       var params = waterlock._utils.allParams(req);
+      var conf = waterlock.config.postActions.register.success;
       if(waterlock._utils.countTopLevel(waterlock.methods) === 1){
-        postResponse = this._resolvePostAction(waterlock.config.postActions.login.success, user);
+        postResponse = this._resolvePostAction(conf, user);
       } else if(params.type) {
-        postResponse = this._resolvePostAction(waterlock.config.postActions.login.success[params.type], user);
+        postResponse = this._resolvePostAction(conf[params.type], user);
       }
 
       if (postResponse === 'jwt') {
@@ -163,8 +164,15 @@ module.exports = function() {
       req.session.user = user;
       req.session.authenticated = true;
       // now respond or redirect
-      var postResponse = this._resolvePostAction(waterlock.config.postActions.login.success,
-        user);
+      var postResponse = user;
+      var params = waterlock._utils.allParams(req);
+      var conf = waterlock.config.postActions.login.success
+      if(waterlock._utils.countTopLevel(waterlock.methods) === 1){
+        postResponse = this._resolvePostAction(conf, user);
+      } else if(params.type) {
+        postResponse = this._resolvePostAction(conf[params.type], user);
+      }
+
       if (postResponse === 'jwt') {
         //Returns the token immediately
         var jwtData = waterlock._utils.createJwt(req, res, user);

--- a/lib/cycle.js
+++ b/lib/cycle.js
@@ -47,7 +47,13 @@ module.exports = function() {
       req.session.authenticated = true;
 
       // now respond or redirect
-      var postResponse = this._resolvePostAction(waterlock.config.postActions.register.success, user);
+      var postResponse = user;
+      var params = waterlock._utils.allParams(req);
+      if(waterlock._utils.countTopLevel(waterlock.methods) === 1){
+        postResponse = this._resolvePostAction(waterlock.config.postActions.login.success, user);
+      } else if(params.type) {
+        postResponse = this._resolvePostAction(waterlock.config.postActions.login.success[params.type], user);
+      }
 
       if (postResponse === 'jwt') {
         //Returns the token immediately

--- a/lib/templates/configs/waterlock.js
+++ b/lib/templates/configs/waterlock.js
@@ -101,6 +101,7 @@ module.exports.waterlock = {
       // url - 'http://example.com'
       // relativePath - '/blog/post'
       // obj - {controller: 'blog', action: 'post'}
+      // obj - {local: "jwt", facebook: '/loginSuccess'}
       // string - 'custom json response string'
       // default - 'default'
       success: 'default',
@@ -143,6 +144,7 @@ module.exports.waterlock = {
      // url - 'http://example.com'
      // relativePath - '/blog/post'
      // obj - {controller: 'blog', action: 'post'}
+     // obj - {local: "jwt", facebook: '/loginSuccess'}
      // string - 'custom json response string'
      // default - 'default'
      success: 'default',


### PR DESCRIPTION
If we set waterlock.config.postActions.login.success to {local: “jwt,
facebook: “/loginsuccess”}
We got jwt response when login type is local and redirect to
/loginsuccess when login type is facebook
