### PR TITLE
Type "text" changed to "string" for sails 1.0 compatibility

### DIFF
--- a/lib/models/jwt.js
+++ b/lib/models/jwt.js
@@ -10,7 +10,7 @@ exports.attributes = function(attributes){
 
   var template = {
     token: {
-      type: 'text',
+      type: 'string',
       maxLength: 512
     },
     uses: {


### PR DESCRIPTION
Hello, while using Waterlock with the new version of Sails 1.0,
got the error of type "text" not being recognized, in the new sails version it has been changed to "string"
Is the master branch intended to work only with previous versions of Sails ?
Regards